### PR TITLE
Enchance download to process distributions separately

### DIFF
--- a/bluepyentity/app/download.py
+++ b/bluepyentity/app/download.py
@@ -8,6 +8,11 @@ import bluepyentity.environments
 @click.command()
 @click.argument("id_")
 @click.option(
+    "--output",
+    default=".",
+    help="Output directory",
+)
+@click.option(
     "--create-links-if-possible",
     is_flag=True,
     required=False,
@@ -15,7 +20,7 @@ import bluepyentity.environments
     help="Try creating symbolic links if the storage type allows it.",
 )
 @click.pass_context
-def download(ctx, id_, create_links_if_possible):
+def download(ctx, id_, output, create_links_if_possible):
     """Download `id` from NEXUS"""
     user = ctx.meta["user"]
     env = ctx.meta["env"]
@@ -23,6 +28,8 @@ def download(ctx, id_, create_links_if_possible):
 
     token = bluepyentity.token.get_token(env=env, username=user)
 
-    forge = bluepyentity.environments.create_forge("prod", token, bucket=bucket)
+    forge = bluepyentity.environments.create_forge(env, token, bucket=bucket)
 
-    bluepyentity.download.download(forge, id_, create_links_if_possible=create_links_if_possible)
+    bluepyentity.download.download(
+        forge, id_, output_dir=output, create_links_if_possible=create_links_if_possible
+    )

--- a/bluepyentity/app/download.py
+++ b/bluepyentity/app/download.py
@@ -6,8 +6,15 @@ import bluepyentity
 
 @click.command()
 @click.argument("id_")
+@click.option(
+    "--create-links-if-possible",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Try creating symbolic links if the storage type allows it.",
+)
 @click.pass_context
-def download(ctx, id_):
+def download(ctx, id_, create_links_if_possible):
     """Download `id` from NEXUS"""
     user = ctx.meta["user"]
     env = ctx.meta["env"]
@@ -15,4 +22,6 @@ def download(ctx, id_):
 
     token = bluepyentity.token.get_token(env=env, username=user)
 
-    bluepyentity.download.download(token, id_, bucket)
+    forge = bluepyentity.environments.create_forge("prod", token, bucket=bucket)
+
+    bluepyentity.download.download(forge, id_, create_links_if_possible=create_links_if_possible)

--- a/bluepyentity/app/download.py
+++ b/bluepyentity/app/download.py
@@ -2,6 +2,7 @@
 import click
 
 import bluepyentity
+import bluepyentity.environments
 
 
 @click.command()

--- a/bluepyentity/app/download.py
+++ b/bluepyentity/app/download.py
@@ -3,6 +3,7 @@
 """download cli entry point"""
 
 import click
+from rich import console, pretty
 
 import bluepyentity
 import bluepyentity.environments
@@ -33,6 +34,9 @@ def download(ctx, id_, output, create_links_if_possible):
 
     forge = bluepyentity.environments.create_forge(env, token, bucket=bucket)
 
-    bluepyentity.download.download(
+    ret = bluepyentity.download.download(
         forge, id_, output_dir=output, create_links_if_possible=create_links_if_possible
     )
+
+    cons = console.Console()
+    pretty.pprint(ret, console=cons)

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -1,34 +1,132 @@
 """download files or create lines based on entities in the knowledge graph"""
 import logging
+import shutil
 from pathlib import Path
+from typing import Dict
 
-import bluepyentity.environments
+from kgforge.core import Resource
+from more_itertools import always_iterable
+
+from bluepyentity.exceptions import BluepyEntityError
 
 L = logging.getLogger(__name__)
 
 
-def download(token, id_, bucket, target_path=None, create_link_if_possible=False):
-    """download files or create lines based on entities in the knowledge graph"""
-    assert target_path is None, "target_path is unsupported, please contribute"
-    assert not create_link_if_possible, "create_link_if_possible is unsupported, please contribute"
+def download(
+    forge, resource_id: str, output_dir: Path = ".", create_links_if_possible: bool = False
+) -> Dict[str, Path]:
+    """Download files based on entities in the knowledge graph.
 
-    forge = bluepyentity.environments.create_forge("prod", token, bucket=bucket)
-    resource = forge.retrieve(id_, cross_bucket=True)
+    Args:
+        forge: KnowledgeGraphForge instance.
+        resource_id: The id of the resource to download.
+        output_dir: Path to output directory. Default is '.'.
+        create_link_if_possible: If True symbolic links will be created instead of copies.
 
-    if isinstance(resource.distribution, list):
-        if len(resource.distribution) == 0:
-            L.error("%s: Resource has nothing to download", id_)
-            return
-        elif len(resource.distribution) > 1:
-            formats = [d.encodingFormat for d in resource.distribution]
-            L.error("%s: Resource has multiple distributions: %s", id_, formats)
-            return
+    Returns:
+        Dictionary the keys of which are the filenames and the values the file paths.
+    """
+    output_dir = Path(output_dir).resolve()
+    resource = forge.retrieve(resource_id, cross_bucket=True)
 
-    if resource.distribution.atLocation.location.startswith("file://"):
-        path = Path(resource.distribution.atLocation.location[7:])
-        if path.exists():
-            (Path() / path.name).symlink_to(path)
-            return
+    if hasattr(resource, "distribution"):
+        return _download_distributions(
+            forge, resource.distribution, output_dir, create_links_if_possible
+        )
 
-    # XXX: should return the path to the file that has been downloaded
-    forge.download(resource.distribution, "contentUrl", ".", overwrite=True)
+    raise BluepyEntityError(f"Resource {resource_id} does not have distributions to download.")
+
+
+def _download_distributions(
+    forge, distributions, output_dir, create_links_if_possible
+) -> Dict[str, Path]:
+
+    paths: Dict[str, Path] = {}
+
+    valid_distributions = (
+        distribution
+        for distribution in always_iterable(distributions)
+        if _is_downloadable(distributions)
+    )
+    for distribution in valid_distributions:
+
+        target_name = distribution.name
+
+        if target_name in paths:
+            raise BluepyEntityError(
+                "Multiple distributions found with the same filename and extension."
+            )
+
+        target_path = output_dir / target_name
+
+        _download_distribution_file(forge, distribution, target_path, create_links_if_possible)
+
+        paths[target_name] = target_path
+
+    return paths
+
+
+def _is_downloadable(distribution):
+    """Return True if distribution has a 'contentUrl'.
+
+    Note: This is also true in the case of gpfs locations.
+    """
+    if not isinstance(distribution, Resource):
+        L.warning("Distribution %s is not a valid resource. Skipped.", distribution)
+        return False
+
+    if distribution.type != "DataDownload":
+        L.warning("Distribution %s is not a DataDownload. Skipped.", distribution)
+        return False
+
+    if not hasattr(distribution, "contentUrl"):
+        L.warning("Distribution %s does not have a 'contentUrl'. Skipped.", distribution)
+        return False
+
+    return True
+
+
+def _has_gpfs_location(distribution):
+    try:
+        return distribution.atLocation.location.startswith("file:///gpfs")
+    except AttributeError:
+        return False
+
+
+def _download_distribution_file(forge, distribution, target_path, create_links_if_possible):
+
+    if _has_gpfs_location(distribution):
+        L.debug("Distribution with file %s has atLocation.", target_path.name)
+        source_path = Path(_remove_prefix("file://", distribution.atLocation.location))
+        _copy_file(source_path, target_path, create_links_if_possible)
+    else:
+        L.debug("Distribution with file %s doesn't have atLocation.", target_path.name)
+        forge.download(
+            distribution, follow="contentUrl", path=target_path.parent, cross_bucket=True
+        )
+
+
+def _remove_prefix(prefix: str, path: str) -> str:
+    """Return the path without the prefix."""
+    if path.startswith(prefix):
+        return path[len(prefix) :]
+    return path
+
+
+def _copy_file(source: Path, target: Path, create_links_if_possible: bool = True) -> Path:
+    source = Path(source).resolve()
+    target = Path(target).resolve()
+
+    if not source.exists():
+        raise BluepyEntityError(f"Source path {source} does not exist.")
+
+    if target.exists():
+        L.info("Target %s already exists and will be replaced.", target)
+        target.unlink()
+
+    if create_links_if_possible:
+        target.symlink_to(source)
+        L.debug("Link %s -> %s", source, target)
+    else:
+        shutil.copy(source, target)
+        L.debug("Copy %s -> %s", source, target)

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -113,20 +113,20 @@ def _remove_prefix(prefix: str, path: str) -> str:
     return path
 
 
-def _copy_file(source: Path, target: Path, create_links_if_possible: bool = True) -> Path:
-    source = Path(source).resolve()
-    target = Path(target).resolve()
+def _copy_file(source_path: Path, target_path: Path, create_link: bool = True) -> Path:
+    source_path = Path(source_path).resolve()
+    target_path = Path(target_path).resolve()
 
-    if not source.exists():
-        raise BluepyEntityError(f"Source path {source} does not exist.")
+    if not source_path.exists():
+        raise BluepyEntityError(f"Source path {source_path} does not exist.")
 
-    if target.exists():
-        L.info("Target %s already exists and will be replaced.", target)
-        target.unlink()
+    if target_path.exists():
+        L.info("Target %s already exists and will be replaced.", target_path)
+        target_path.unlink()
 
-    if create_links_if_possible:
-        target.symlink_to(source)
-        L.debug("Link %s -> %s", source, target)
+    if create_link:
+        target_path.symlink_to(source_path)
+        L.debug("Link %s -> %s", source_path, target_path)
     else:
-        shutil.copy(source, target)
-        L.debug("Copy %s -> %s", source, target)
+        shutil.copy(source_path, target_path)
+        L.debug("Copy %s -> %s", source_path, target_path)

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -51,7 +51,7 @@ def _download_distributions(
         if _is_downloadable(distribution)
     )
     for distribution in valid_distributions:
-
+        # pylint: disable=protected-access
         # temp hack to fix the nonexistent store metadata
         if not hasattr(distribution, "_store_metadata") or not distribution._store_metadata:
             assert resource._store_metadata
@@ -105,7 +105,12 @@ def _download_distribution_file(forge, distribution, target_path, create_links_i
     if _has_gpfs_location(distribution):
         L.debug("Distribution with file %s has atLocation.", target_path.name)
         source_path = Path(_remove_prefix("file://", distribution.atLocation.location))
-        _copy_file(source_path, target_path, create_links_if_possible)
+        if source_path.exists():
+            _copy_file(source_path, target_path, create_links_if_possible)
+        else:
+            forge.download(
+                distribution, follow="contentUrl", path=target_path.parent, cross_bucket=True
+            )
     else:
         L.debug("Distribution with file %s doesn't have atLocation.", target_path.name)
         forge.download(

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -1,4 +1,6 @@
 """download files or create lines based on entities in the knowledge graph"""
+from __future__ import annotations
+
 import logging
 import shutil
 from pathlib import Path
@@ -13,7 +15,7 @@ L = logging.getLogger(__name__)
 
 
 def download(
-    forge, resource_id: str, output_dir: Path = ".", create_links_if_possible: bool = False
+    forge, resource_id: str, output_dir: Path | str = ".", create_links_if_possible: bool = False
 ) -> Dict[str, Path]:
     """Download files based on entities in the knowledge graph.
 

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -46,7 +46,7 @@ def _download_distributions(
     valid_distributions = (
         distribution
         for distribution in always_iterable(distributions)
-        if _is_downloadable(distributions)
+        if _is_downloadable(distribution)
     )
     for distribution in valid_distributions:
 

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -32,25 +32,28 @@ def download(
     resource = forge.retrieve(resource_id, cross_bucket=True)
 
     if hasattr(resource, "distribution"):
-        return _download_distributions(
-            forge, resource.distribution, output_dir, create_links_if_possible
-        )
+        return _download_distributions(forge, resource, output_dir, create_links_if_possible)
 
     raise BluepyEntityError(f"Resource {resource_id} does not have distributions to download.")
 
 
 def _download_distributions(
-    forge, distributions, output_dir, create_links_if_possible
+    forge, resource, output_dir, create_links_if_possible
 ) -> Dict[str, Path]:
 
     paths: Dict[str, Path] = {}
 
     valid_distributions = (
         distribution
-        for distribution in always_iterable(distributions)
+        for distribution in always_iterable(resource.distribution)
         if _is_downloadable(distribution)
     )
     for distribution in valid_distributions:
+
+        # temp hack to fix the nonexistent store metadata
+        if not hasattr(distribution, "_store_metadata") or not distribution._store_metadata:
+            assert resource._store_metadata
+            distribution._store_metadata = resource._store_metadata
 
         target_name = distribution.name
 

--- a/bluepyentity/exceptions.py
+++ b/bluepyentity/exceptions.py
@@ -1,0 +1,5 @@
+"""bluepyentity exceptions."""
+
+
+class BluepyEntityError(Exception):
+    """bluepyentity error."""

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "nexusforge>=0.7.0,<1.0.0",
         "pyjwt",
         "rich",
+        "more-itertools",
     ],
     packages=find_packages(),
     python_requires=">=3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,8 @@ allowlist_externals = make
 # W503: line break after binary operator
 # W504: line break before binary operator
 # E501: line too long (checked with pylint)
-ignore = E731,W503,W504,E501
+# E203: whitespace before ':'
+ignore = E731,W503,W504,E501, E203
 
 [pydocstyle]
 # ignore the following


### PR DESCRIPTION
Enhance `download` to allow processing more types of downloadable KG resources within reason.

**Features**
* Option to create links wherever possible.
* Handle both gpfs files and content only available via `contentUrl`.
* download() returns a dictionary with the downloaded paths.

**Assumptions:**
* Downloadable resources always have a `DataDownload` type.
* Downloadable resources always have a `contentUrl` attribute. This is true for all store types.
* Distributions with gpfs paths should satisfy `distribution.atLocation.location.startswith("file:///gpfs")`
* Distributions always have a name (questionable).

**Restrictions**
* More than one distribution with identical files (extension included) are not allowed

**Questions**
* Are there resources with `contentUrl` but no `distribution`?
* Are there other types of downloadable content that should be considered?
* Are other cases currently not taken care of (see below for the current list)?
* What do we do with the `url` entry. Is it sensible/expected to have downloadable content?
* Other features of interest? e.g filter by mime type, add user-provided target renaming, etc.?

Example Cases
---------

### Two distributions, but one is not like the other

[https://bbp.epfl.ch/neurosciencegraph/data/1e2d3085-b591-4041-a33f-d8220cd72a61?rev=12](https://bbp.epfl.ch/nexus/web/bbp/neocortex/resources/https%253A%252F%252Fbbp.epfl.ch%252Fneurosciencegraph%252Fdata%252F1e2d3085-b591-4041-a33f-d8220cd72a61?rev=12)
<details>

```python
  "distribution": [
    {
      "@type": "DataDownload",
      "contentUrl": "https://bbp.epfl.ch/nexus/v1/files/bbp/neocortex/e3fbe8c5-dd8c-41b1-9953-e22738f1405b",
      "encodingFormat": "application/nwb",
      "name": "534524026.nwb"
    },
    {
      "@type": "DataDownload",
      "repository": {
        "@id": "http://celltypes.brain-map.org/",
        "name": "Allen Cell Types Database"
      },
      "url": "http://celltypes.brain-map.org/experiment/electrophysiology/534524026"
    }
  ],
```

</details>

Behavior:
* Distribution 1: contentUrl -> forge.download to output directory
* Distribution 2: No contentUrl -> skip

### Distributions with atLocation but with a DiskStorage type of store

[https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a62417c8-704a-44fe-9088-854ed8bb2a35?rev=9](https://bbp.epfl.ch/nexus/v1/resources/bbp/mouselight/datashapes:neuronmorphology/neuronmorphologies%2Fa62417c8-704a-44fe-9088-854ed8bb2a35?rev=9)
<details>

```python
 "distribution": [
    {
      "@type": "DataDownload",
      "atLocation": {
        "@type": "Location",
        "store": {
          "@id": "https://bluebrain.github.io/nexus/vocabulary/diskStorageDefault",
          "@type": "DiskStorage",
          "_rev": 1
        }
      },
      "contentUrl": "https://bbp.epfl.ch/nexus/v1/files/bbp/mouselight/be3cf189-776e-4915-b27d-c5c84448b422",
      "encodingFormat": "application/swc",
      "name": "AA0390.swc"
    },
    {
      "@type": "DataDownload",
      "atLocation": {
        "@type": "Location",
        "store": {
          "@id": "https://bluebrain.github.io/nexus/vocabulary/diskStorageDefault",
          "@type": "DiskStorage",
          "_rev": 1
        }
      },
      "contentUrl": "https://bbp.epfl.ch/nexus/v1/files/bbp/mouselight/1b77f913-dcd8-4706-a596-c6f7f6063d33",
      "encodingFormat": "application/asc",
      "name": "AA0390.asc"
    },
    {
      "@type": "DataDownload",
      "atLocation": {
        "@type": "Location",
        "store": {
          "@id": "https://bluebrain.github.io/nexus/vocabulary/diskStorageDefault",
          "@type": "DiskStorage",
          "_rev": 1
        }
      },
      "contentUrl": "https://bbp.epfl.ch/nexus/v1/files/bbp/mouselight/bd1a34ad-5bc4-4856-b53a-144f74d3aac7",
      "encodingFormat": "application/h5",
      "name": "AA0390.h5"
    }
  ],
```
</details>

Behavior:
* Given that there is no gpfs path -> forge.download contentUrl

### Distribution with a RemoteDiskStorage and atLocation.location gpfs path

[https://bbp.epfl.ch/neurosciencegraph/data/d6fe7775-0f20-48f5-8819-825d392122d9?rev=1](https://bbp.epfl.ch/nexus/web/bbp/mmb-point-neuron-framework-model/resources/https%253A%252F%252Fbbp.epfl.ch%252Fneurosciencegraph%252Fdata%252Fd6fe7775-0f20-48f5-8819-825d392122d9?rev=1)
<details>

```python
 "distribution": {
    "@type": "DataDownload",
    "atLocation": {
      "@type": "Location",
      "location": "file:///gpfs/bbp.cscs.ch/data/project/proj134/nexus/bbp/mmb-point-neuron-framework-model/0/1/3/d/d/d/a/8/bNAC.hoc",
      "store": {
        "@id": "https://bbp.epfl.ch/neurosciencegraph/data/10419671-da26-48d3-abf9-51eb54759ca4",
        "@type": "RemoteDiskStorage",
        "_rev": 1
      }
    },
    "contentUrl": "https://bbp.epfl.ch/nexus/v1/files/bbp/mmb-point-neuron-framework-model/1e7334b5-bc82-47b6-b963-f24144bb741f",
}
```
</details>

Behavior:
* copy to output directory if `create_links_if_possible` is False
* create symlink to output directory if `create_links_if_possilbe` is True
