### PR TITLE
Relax download distribution location to any location that exists

### DIFF
--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -117,13 +117,7 @@ def _download_distribution_file(forge, distribution, target_path, create_links_i
 
     if filesystem_location:
         L.debug("Distribution with file %s has atLocation.", target_path.name)
-        source_path = filesystem_location
-        if source_path.exists():
-            _copy_file(source_path, target_path, create_links_if_possible)
-        else:
-            forge.download(
-                distribution, follow="contentUrl", path=target_path.parent, cross_bucket=True
-            )
+        _copy_file(filesystem_location, target_path, create_links_if_possible)
     else:
         L.debug("Distribution with file %s doesn't have atLocation.", target_path.name)
         forge.download(

--- a/bluepyentity/download.py
+++ b/bluepyentity/download.py
@@ -93,18 +93,31 @@ def _is_downloadable(distribution):
     return True
 
 
-def _has_gpfs_location(distribution):
+def _get_filesystem_location(distribution):
+    """Return a filesystem location if it's available and exists, otherwise None."""
     try:
-        return distribution.atLocation.location.startswith("file:///gpfs")
+        location = distribution.atLocation.location
     except AttributeError:
-        return False
+        L.debug("Distribution object doesn't have an atLocation.")
+        return None
+
+    location = Path(_remove_prefix("file://", location))
+
+    if location.exists():
+        L.debug("Distribution atLocation location path %s found.", location)
+        return location
+
+    L.debug("Distribution atLocation location path %s does not exist.", location)
+    return None
 
 
 def _download_distribution_file(forge, distribution, target_path, create_links_if_possible):
 
-    if _has_gpfs_location(distribution):
+    filesystem_location = _get_filesystem_location(distribution)
+
+    if filesystem_location:
         L.debug("Distribution with file %s has atLocation.", target_path.name)
-        source_path = Path(_remove_prefix("file://", distribution.atLocation.location))
+        source_path = filesystem_location
         if source_path.exists():
             _copy_file(source_path, target_path, create_links_if_possible)
         else:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,37 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+from bluepyentity import download as tested
+
+
+def test_get_filesystem_location__no_resource_attributes():
+    class Empty:
+        """Empty"""
+
+    res = tested._get_filesystem_location(Empty())
+    assert res is None
+
+
+def test_get_filesystem_location__non_existing_path():
+
+    mock = Mock()
+    mock.atLocation.location = "road-to-camelot"
+    res = tested._get_filesystem_location(mock)
+    assert res is None
+
+
+def test_get_filesystem_location():
+
+    with tempfile.NamedTemporaryFile() as tfile:
+        path = Path(tfile.name)
+
+        mock = Mock()
+        # without file:// prefix
+        mock.atLocation.location = str(path)
+        res = tested._get_filesystem_location(mock)
+        assert res == path
+
+        # with file:// prefix
+        mock.atLocation.location = f"file://{path}"
+        res = tested._get_filesystem_location(mock)
+        assert res == path


### PR DESCRIPTION
Relax the check for a gpfs location to any location as far as the path exists.

There is no reason to have a gpfs constraint and it makes things easier with mocking/tests.