### PR TITLE
Package data not included in dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "textual==0.9.1",  # API is unstable, hence the pinning.
     ],
     packages=find_packages(),
+    include_package_data=True,
     python_requires=">=3.7",
     extras_require={
         "docs": ["sphinx", "sphinx-bluebrain-theme"],

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     pydocstyle
     pylint
     isort
-    black
+    black==22.12.0
 commands =
     isort --check-only --diff {[base]name}
     black --check .
@@ -51,7 +51,7 @@ commands =
 [testenv:format]
 deps =
     isort
-    black
+    black==22.12.0
 commands =
     isort {[base]name}
     black .


### PR DESCRIPTION
**Issue:**
The configuration file was not included in the dist resulting in errors such as:
```python
FileNotFoundError: [Errno 2] No such file or directory: '/home/eleftherios/global_venv/lib/python3.9/site-packages/bluepyentity/data/prod-forge-nexus.yaml'
```
**Fix**
Enable `include_package_data` in setup.py. The manifest file is already set correctly.

I also pinned black so that I didn't have to format all files with the new style for this PR.